### PR TITLE
Add class-based MCP server and client

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,1 +1,43 @@
-a
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+// Example MCP client implemented as a class
+
+class ExampleClient {
+	readonly client: Client;
+	readonly transport: StdioClientTransport;
+
+	constructor() {
+		this.transport = new StdioClientTransport({
+			command: "bun",
+			args: ["run", "src/mcp/server.ts"],
+		});
+		this.client = new Client({ name: "example-client", version: "1.0.0" });
+	}
+
+	async run(): Promise<void> {
+		await this.client.connect(this.transport);
+
+		const addResult = await this.client.callTool({
+			name: "add",
+			arguments: { a: 2, b: 3 },
+		});
+		console.log("add result", addResult.content?.[0]?.text);
+
+		const greeting = await this.client.readResource({
+			uri: "greeting://Alice",
+		});
+		console.log("greeting", greeting.contents[0]?.text);
+
+		await this.client.close();
+	}
+}
+
+export { ExampleClient };
+
+if (import.meta.main) {
+	new ExampleClient().run().catch((err) => {
+		console.error(err);
+		process.exit(1);
+	});
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,1 +1,134 @@
-a
+import {
+	McpServer,
+	ResourceTemplate,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { completable } from "@modelcontextprotocol/sdk/server/completable.js";
+import { z } from "zod";
+
+// Example MCP server demonstrating tools, resources and prompts implemented as a class
+
+class ExampleServer {
+	readonly server: McpServer;
+	readonly transport: StdioServerTransport;
+
+	constructor() {
+		this.server = new McpServer({
+			name: "demo-server",
+			version: "1.0.0",
+		});
+		this.transport = new StdioServerTransport();
+		this.registerHandlers();
+	}
+
+	private registerHandlers(): void {
+		// Addition tool
+		this.server.registerTool(
+			"add",
+			{
+				title: "Addition Tool",
+				description: "Add two numbers",
+				inputSchema: { a: z.number(), b: z.number() },
+			},
+			async ({ a, b }) => ({
+				content: [{ type: "text", text: String(a + b) }],
+			}),
+		);
+
+		// Dynamic greeting resource
+		this.server.registerResource(
+			"greeting",
+			new ResourceTemplate("greeting://{name}", { list: undefined }),
+			{
+				title: "Greeting Resource",
+				description: "Dynamic greeting generator",
+			},
+			async (uri, { name }) => ({
+				contents: [
+					{
+						uri: uri.href,
+						text: `Hello, ${name}!`,
+					},
+				],
+			}),
+		);
+
+		// Simple prompts
+		this.server.registerPrompt(
+			"review-code",
+			{
+				title: "Code Review",
+				description: "Review code for best practices and potential issues",
+				argsSchema: { code: z.string() },
+			},
+			({ code }) => ({
+				messages: [
+					{
+						role: "user",
+						content: {
+							type: "text",
+							text: `Please review this code:\n\n${code}`,
+						},
+					},
+				],
+			}),
+		);
+
+		// Prompt with completions
+		this.server.registerPrompt(
+			"team-greeting",
+			{
+				title: "Team Greeting",
+				description: "Generate a greeting for team members",
+				argsSchema: {
+					department: completable(z.string(), (value) =>
+						["engineering", "sales", "marketing", "support"].filter((d) =>
+							d.startsWith(value),
+						),
+					),
+					name: completable(z.string(), (value, context) => {
+						const dept = context?.arguments?.["department"];
+						if (dept === "engineering") {
+							return ["Alice", "Bob", "Charlie"].filter((n) =>
+								n.startsWith(value),
+							);
+						} else if (dept === "sales") {
+							return ["David", "Eve", "Frank"].filter((n) =>
+								n.startsWith(value),
+							);
+						} else if (dept === "marketing") {
+							return ["Grace", "Henry", "Iris"].filter((n) =>
+								n.startsWith(value),
+							);
+						}
+						return ["Guest"].filter((n) => n.startsWith(value));
+					}),
+				},
+			},
+			({ department, name }) => ({
+				messages: [
+					{
+						role: "assistant",
+						content: {
+							type: "text",
+							text: `Hello ${name}, welcome to the ${department} team!`,
+						},
+					},
+				],
+			}),
+		);
+	}
+
+	async start(): Promise<void> {
+		await this.server.connect(this.transport);
+	}
+}
+
+export { ExampleServer };
+
+if (import.meta.main) {
+	const srv = new ExampleServer();
+	srv.start().catch((err) => {
+		console.error("Failed to start MCP server", err);
+	});
+}


### PR DESCRIPTION
## Summary
- refactor example server into `ExampleServer` class
- refactor example client into `ExampleClient` class

## Testing
- `npm run fmt`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f95c6aa288330bddc2a5d4335a6d0