### PR TITLE
Support HTTP transport

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,17 +1,14 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 // Example MCP client implemented as a class
 
 class ExampleClient {
 	readonly client: Client;
-	readonly transport: StdioClientTransport;
+	readonly transport: StreamableHTTPClientTransport;
 
-	constructor() {
-		this.transport = new StdioClientTransport({
-			command: "bun",
-			args: ["run", "src/mcp/server.ts"],
-		});
+	constructor(serverUrl = "http://localhost:3000/mcp") {
+		this.transport = new StreamableHTTPClientTransport(serverUrl, {});
 		this.client = new Client({
 			name: "example-client",
 			version: process.env.npm_package_version ?? "1.0.0",


### PR DESCRIPTION
## Summary
- use `StreamableHTTPServerTransport` with `http` server in `ExampleServer`
- use `StreamableHTTPClientTransport` in `ExampleClient`

## Testing
- `bun run fmt`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_685fa3b881e8833099401e440d083b09